### PR TITLE
BEP-39: Add MEMO to Transfer WebSocket.

### DIFF
--- a/BEP39.md
+++ b/BEP39.md
@@ -1,0 +1,65 @@
+# BEP-39: Add MEMO to Transfer WebSocket.
+
+- BEP-39: Add MEMO to Transfer WebSocket
+  - [1. Summary](#1-summary)
+  - [2. Abstract](#2-abstract)
+  - [3. Status](#3-status)
+  - [4. Motivation](#4-motivation)
+  - [5. Specification](#5-specification)
+    - [5.1 Websocket](#51-websocket)
+  - [6. License](#6-license)
+
+## 1.  Summary 
+
+This BEP describes an improvement to the [Transfer Websocket](https://docs.binance.org/api-reference/dex-api/ws-streams.html#3-transfer).  
+
+## 2.  Abstract
+
+BEP-39 requests that `MEMO` data field be added to the `/ws/userAddress` websocket. 
+
+Currently the `MEMO` field is not being returned on the websocket, which means that services that rely on `MEMO` to set transaction specifications must then retrieve it from the [Transaction API endpoint](https://docs.binance.org/api-reference/dex-api/paths.html#transaction).
+
+This creates unneccessary burden on the API and slows down the transaction processing. 
+
+The solution is to add it to the Transfer Websocket as a data field to stream. 
+
+## 3.  Status
+
+This BEP is under specification.
+
+## 4.  Motivation
+
+Wallets, exchanges, dApps and other services will set transaction state in the `MEMO` to allow them to be stateless. 
+
+To improve the speed at which the `MEMO` field can be read and processed, it should be added to the websocket so it doesn't burden Binance Node API endpoints, which are rate-limited. 
+
+## 5.  Specification
+
+###  5.1 Websocket
+
+The following is the update for the `/ws/userAddress` websocket with the added `MEMO` field:
+
+```
+{
+  "stream": "transfers",
+  "data": {
+    "e":"outboundTransferInfo",                                                // Event type
+    "E":12893,                                                                 // Event height
+    "H":"0434786487A1F4AE35D49FAE3C6F012A2AAF8DD59EC860DC7E77123B761DD91B",    // Transaction hash
+    "f":"bnb1z220ps26qlwfgz5dew9hdxe8m5malre3qy6zr9",                          // From addr
+    "t":
+      [{
+        "o":"bnb1xngdalruw8g23eqvpx9klmtttwvnlk2x4lfccu",                      // To addr
+        "c":[{                                                                 // Coins
+          "a":"BNB",                                                           // Asset
+          "A":"100.00000000"                                                   // Amount
+          "M": "MEMO"                                                          // Memo
+          }]
+      }]
+  }
+}
+```
+
+## 6. License
+
+The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
# BEP-39: Add MEMO to Transfer WebSocket.

BEP-39 requests that `MEMO` data field be added to the `/ws/userAddress` [websocket](https://docs.binance.org/api-reference/dex-api/ws-streams.html#3-transfer).

Currently the `MEMO` field is not being returned on the websocket, which means that services that rely on MEMO to set transaction specifications must then retrieve it from the [Transaction API endpoint](https://docs.binance.org/api-reference/dex-api/paths.html#transaction).

This creates unneccessary burden on the API and slows down the transaction processing.

The solution is to add it to the Transfer Websocket as a data field to stream.