### PR TITLE
Register TrustToken Source

### DIFF
--- a/BEP10.md
+++ b/BEP10.md
@@ -74,7 +74,7 @@ All of these constant values shall be considered hardcoded in client implementat
 | 711        | [CoolWallet S](https://coolwallet.io/)|
 | 714        | Binance|
 | 777        | Guarda Wallet [Multi-currency, custody-free wallet](https://guarda.co/)
-| 888        | TrustToken ([app](https://app.trusttoken.com), [issuer](https://explorer.binance.org/address/bnb100dxzy02a6k7vysc5g4kk4fqamr7jhjg4m83l0))
+| 888        | TrustToken: [Cross-chain, multi-currency fiat onramp+offramp](https://app.trusttoken.com)|
 | 800,000,000 ~ 1,600,000,000| reserved source code|
 
 

--- a/BEP10.md
+++ b/BEP10.md
@@ -74,6 +74,7 @@ All of these constant values shall be considered hardcoded in client implementat
 | 711        | [CoolWallet S](https://coolwallet.io/)|
 | 714        | Binance|
 | 777        | Guarda Wallet [Multi-currency, custody-free wallet](https://guarda.co/)
+| 888        | TrustToken ([app](https://app.trusttoken.com), [issuer](https://explorer.binance.org/address/bnb100dxzy02a6k7vysc5g4kk4fqamr7jhjg4m83l0))
 | 800,000,000 ~ 1,600,000,000| reserved source code|
 
 


### PR DESCRIPTION
#### Changes
The TrustToken issuer uses source 888.
All transactions from our hardware security module will use source 888.
This is because our token issuing transactions begin with hash 888.
Many of our other transaction hashes will also start with 8, but all will use source 888.
##### Examples 
[Issue TUSDB-888](https://dex.binance.org/api/v1/tx/888097BB8AEA13E880FFE309C74D07A0495784BEE035F5490264051F9FB67362?format=json)
[Issue TAUDB-888](https://dex.binance.org/api/v1/tx/8883D78BBD2B6328517B74E7770331ADB97A8B6D690D4112173D600D031F816E?format=json)
[Transfer TUSDB-888](https://dex.binance.org/api/v1/tx/8E115B989047DECF5C3D5617DDDDA3E80BDADF16EA9B702B9E36F510C1AD745D?format=json)

Reviewers @huangsuyu